### PR TITLE
Use node8 published image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,3 +24,5 @@ ENV PATH="/build/artifacts/bin:${PATH}"
 WORKDIR /build/sai
 
 RUN dapp build
+
+WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,26 @@
-FROM node@sha256:dbb1e74774617c46a34f67d25decbdc5841af2a2a08a125a37743c734799b909 as builder
-# Docker Tag: node:8.11.1-stretch
-
-ADD ./vendor /tmp/vendor
+FROM keydonix/parity-instantseal-node8
+# TODO: use digest
 
 WORKDIR /build
 
-# install vendor'd tools and dependencies
-RUN dpkg -i /tmp/vendor/*.deb
+# TODO: vendor
+RUN apt-get update && apt-get -y install software-properties-common git make && \
+	add-apt-repository ppa:ethereum/ethereum && \
+	apt-get update && \
+	apt-get install -y solc
 
 RUN git clone https://github.com/makerdao/sai.git && \
 	( cd sai && \
 	git checkout 56eed66bb42a485ff0819f4ca227f615b1eb5320 && \
 	git submodule update --init --recursive )
 
-# steps to install Nix and DappHub tools
-RUN mkdir makertools && cd makertools && \
-	git clone https://github.com/dapphub/seth && \
-	(cd seth && git checkout de7048815c4953da391b93179af9c2c162e59b23) && \
+RUN mkdir artifacts && mkdir tools && cd tools && \
 	git clone https://github.com/dapphub/dapp && \
 	(cd dapp && git checkout a426596705be4dfcdd60e7965163453574459dcf) && \
-	git clone https://github.com/dapphub/ethsign && \
-	(cd ethsign && git checkout d7591c9cac762f15c7087c2d066176bb75ba8095) && \
-	git clone https://github.com/keenerd/jshon.git && \
-	(cd jshon && git checkout d919aeaece37962251dbe6c1ee50f0028a5c90e4) && \
-	make link -C seth prefix=/build/artifacts && \
-	make link -C dapp prefix=/build/artifacts && \
-	make -C jshon LDFLAGS="-static" && \
-	make install -C jshon TARGET_PATH=/build/artifacts/bin
+        make install -C dapp prefix=/build/artifacts
 
 ENV PATH="/build/artifacts/bin:${PATH}"
 
 WORKDIR /build/sai
+
 RUN dapp build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM keydonix/parity-instantseal-node8
+FROM keydonix/parity-instantseal
 # TODO: use digest
 
 WORKDIR /build
@@ -17,7 +17,7 @@ RUN git clone https://github.com/makerdao/sai.git && \
 RUN mkdir artifacts && mkdir tools && cd tools && \
 	git clone https://github.com/dapphub/dapp && \
 	(cd dapp && git checkout a426596705be4dfcdd60e7965163453574459dcf) && \
-        make install -C dapp prefix=/build/artifacts
+	make install -C dapp prefix=/build/artifacts
 
 ENV PATH="/build/artifacts/bin:${PATH}"
 


### PR DESCRIPTION
This will be one of the builders, with sai's aritifacts (/build/sai/out/) copied in to the next phase for deployment into a local parity with typescript.

This didn't need to have parity, but i figured we needed node8, and since we're using it later, it is less to trust